### PR TITLE
Updated  bcrypt to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bcrypt": "^0.8.7",
+    "bcrypt": "^1.0.2",
     "mongodb": "^2.2.10",
     "passwordless-tokenstore": "0.0.10"
   },


### PR DESCRIPTION
The previous version v0.8.7 is no longer compatible with node-gyp build tools on windows. 
Bcrypt @ v.0.8.7 breaks with error message "MSBUILD : error MSB4132: The tools version "2.0" is unrecognized. Available tools versions are '12.0', '4.0' ". 
Updating to latest version solves the issue.